### PR TITLE
Separate primefaces-showcase from paraya-micro

### DIFF
--- a/payara-micro/Dockerfile
+++ b/payara-micro/Dockerfile
@@ -32,7 +32,6 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 
 RUN useradd -b /opt -m -s /bin/bash payara && echo payara:payara | chpasswd
 RUN cd /opt && wget $PAYARA_PKG
-RUN cd /opt && wget http://repository.primefaces.org/org/primefaces/showcase/5.2/showcase-5.2.war
 RUN chown -R payara:payara /opt
 
 

--- a/payara-micro/demo-primefaces-showcase/Dockerfile
+++ b/payara-micro/demo-primefaces-showcase/Dockerfile
@@ -1,0 +1,6 @@
+FROM payaradocker/payara-micro
+MAINTAINER Toshiaki Maki <makingx at gmail.com>
+
+ADD showcase-5.2.war /opt/
+WORKDIR /opt/
+ENTRYPOINT ["java", "-jar", "payara-micro-4.1.152.1.jar", "--deploy", "showcase-5.2.war"]

--- a/payara-micro/demo-primefaces-showcase/buildimage.sh
+++ b/payara-micro/demo-primefaces-showcase/buildimage.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+IMAGE_NAME=payara-demo-primefaces-showcase
+
+wget http://repository.primefaces.org/org/primefaces/showcase/5.2/showcase-5.2.war
+docker build -t $IMAGE_NAME .


### PR DESCRIPTION
Current [Dockerfile](https://github.com/payara/docker/blob/1a3ee2274a4bf471aed1ac44d29a8244ef9dfe6c/payara-micro/Dockerfile) for Payara Micro contains primefaces-showcase.war.

So I separated it into the demo folder.
This change makes creating portable app image very easy.

[This Dockerfile](https://github.com/making/payara-docker/blob/a8836eb28f0dfe9a88fc5394b6a09dd8c2ecb399/payara-micro/demo-primefaces-showcase/Dockerfile) is my experimental one.
Using this portable image, you can run the application quickly.

``` bash
$ docker run -p 8080:8080 -ti --rm making/payara-demo-primefaces-showcase
``` 

Changing port is also easy

```
$ docker run -p 8081:8081 -ti --rm making/payara-demo-primefaces-showcase --port 8081
```

I'd like to use office demo image as follows ;)
```
$ docker run -p 8080:8080 -ti --rm payaradocker/payara-demo-primefaces-showcase
``` 
PS:
This Dockerfile of the demo requires `payaradocker/payara-micro:latest` which is not pushed yet.